### PR TITLE
fix: replace deprecated onCatalystInstanceDestroy with invalidate, narrow event type

### DIFF
--- a/android/src/main/java/com/netsignal/NetSignalTurboModule.kt
+++ b/android/src/main/java/com/netsignal/NetSignalTurboModule.kt
@@ -209,7 +209,8 @@ class NetSignalTurboModule(private val reactContext: ReactApplicationContext) :
         }
     }
 
-    override fun onCatalystInstanceDestroy() {
+    override fun invalidate() {
+        super.invalidate()
         stopListening()
         listenerCount.set(0)
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,7 +24,7 @@ export interface Connection {
 
 export type NetworkChangeEvent = {
   isConnected: boolean;
-  type: string;
+  type: ConnectionType;
   connectionCount: number;
 };
 
@@ -84,7 +84,7 @@ function notifyStoreListeners(): void {
 function handleNativeEvent(event: NetworkChangeEvent): void {
   currentState = {
     connected: event.isConnected,
-    type: event.type as ConnectionType,
+    type: event.type,
     connectionCount: event.connectionCount,
     multipleConnections: event.connectionCount > 1,
   };


### PR DESCRIPTION
## Summary

Two correctness fixes for RN 0.80:

- **`NetSignalTurboModule` uses `invalidate()`** instead of `onCatalystInstanceDestroy()`. RN 0.80's `NativeModule.java:64` marks the latter `@Deprecated(forRemoval = true)`. Once RN drops the default impl, the current hook silently stops running → leaked `NetworkCallback` on app teardown.
- **`NetworkChangeEvent.type` is now `ConnectionType`** instead of `string`. Matches the rest of the public API and restores caller-side narrowing. The redundant `as ConnectionType` cast in `handleNativeEvent` is removed.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `biome check src/ __tests__/` clean
- [x] `jest` — 21/21 pass
- [ ] Manual: run example on a device after merge, confirm network callback still registers/unregisters cleanly on app foreground/background