### PR TITLE
chore: polish — doc dual-dispatch, mark test helper @internal, add prepublishOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ const unsubscribe = NetSignal.addEventListener((event) => {
 });
 ```
 
+`addEventListener` runs in parallel with the hook store — if you also use `useNetworkState` (or a sibling hook), both your callback and the hook will fire on every native event. Pick one per component to avoid redundant work.
+
 ### React Hooks
 
 ```typescript

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint": "biome check src/ __tests__/",
     "lint:fix": "biome check --fix src/ __tests__/",
     "prepare": "bob build",
+    "prepublishOnly": "bun run typecheck && bun run lint && jest && bob build",
     "release": "release-it"
   },
   "keywords": [

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,6 +42,7 @@ const storeListeners = new Set<() => void>();
 let nativeSubscription: (() => void) | null = null;
 let nativeListenerCount = 0;
 
+/** @internal Only for unit tests; not part of the stable API. */
 export function _resetForTesting(): void {
   currentState = {
     connected: false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["es2017"],
     "jsx": "react-native",
     "declaration": true,
-    "outDir": "./lib",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## Summary

Three low-risk polish items + one followup from PR 2's bob warning:

- **README:** note that `addEventListener` fires alongside the hook store, so mixing both in one component means redundant work.
- **`_resetForTesting`:** tagged `/** @internal */` so consumers with `stripInternal: true` in their tsconfig drop it from autocomplete. Underscore prefix + export kept for backward compat.
- **`prepublishOnly`:** adds `bun run typecheck && bun run lint && jest && bob build` so even without CI, a broken release can't be published.
- **`tsconfig.json`:** drop `compilerOptions.outDir` (bob owns the output path and warned about the conflict in PR 2's build).

## Test plan

- [x] `tsc --noEmit` passes (no outDir warning)
- [x] `biome check` clean
- [x] `jest` — 21/21 pass
- [x] `bob build` — CJS + ESM + types emit with zero warnings now