### PR TITLE
chore: harden supply chain — provenance, sideEffects, dependabot, security policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,15 @@ jobs:
 
       - name: Build (bob)
         run: bunx bob build
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Publish to npm (with provenance)
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run typecheck
+      - run: bun run lint
+      - run: bunx jest --ci
+      - run: bunx bob build
+
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+The latest minor of `netsignal` receives security fixes.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.0.x   | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+Please report security issues privately via GitHub's
+[private vulnerability reporting](https://github.com/anivar/netsignal/security/advisories/new).
+
+Do **not** open a public issue for security problems.
+
+You should receive an acknowledgement within 72 hours. If the issue is
+confirmed, a fix and a coordinated disclosure timeline will follow.

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -5,7 +5,7 @@ ruby ">= 2.6.10"
 
 # Exclude problematic versions of cocoapods and activesupport that causes build failures.
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
-gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
+gem 'activesupport', '>= 7.1.5.1', '!= 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
 gem 'concurrent-ruby', '< 1.3.4'
 

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "netsignal",
   "version": "1.0.2",
   "description": "Ultra-fast network state for React Native 0.80+ (New Architecture)",
-  "main": "lib/commonjs/index",
-  "module": "lib/module/index",
+  "main": "lib/commonjs/index.js",
+  "module": "lib/module/index.js",
   "types": "lib/typescript/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
+  "sideEffects": false,
   "files": [
     "src",
     "lib",
@@ -42,6 +43,7 @@
     "url": "https://github.com/anivar/netsignal/issues"
   },
   "homepage": "https://github.com/anivar/netsignal#readme",
+  "funding": "https://github.com/sponsors/anivar",
   "packageManager": "bun@1.3.13",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Pushes netsignal toward a higher Socket score and enables managed security updates.

## Added

- **\`.github/dependabot.yml\`** — weekly npm + github-actions update PRs; dev deps grouped.
- **\`SECURITY.md\`** — disclosure policy via GitHub private vulnerability reporting.
- **\`.github/workflows/release.yml\`** — tag-triggered (\`v*.*.*\`) npm publish using GitHub Actions OIDC + \`npm publish --provenance\`. Requires \`NPM_TOKEN\` repo secret.
- **CI dependency-review job** — \`actions/dependency-review-action\` on PRs, \`fail-on-severity: high\`.

## package.json

- \`sideEffects: false\` — tree-shaking hint (no module-level side effects in src/).
- \`funding\` field → \`https://github.com/sponsors/anivar\`.
- \`main\`/\`module\` now point at explicit \`.js\` paths (was extension-less).

## Verification

- \`bun run typecheck\` ✅
- \`bunx jest --ci\` → 21/21 passing ✅
- \`bunx bob build\` clean (no warnings) ✅
- \`npm pack --dry-run\` → 22 files (unchanged) ✅