### PR TITLE
docs: note that example/ios scaffolding is unused

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,5 +1,7 @@
 This is a new [**React Native**](https://reactnative.dev) project, bootstrapped using [`@react-native-community/cli`](https://github.com/react-native-community/cli).
 
+> **Note:** NetSignal is **Android only**. The `ios/` folder and `npm run ios` script below are leftover scaffolding from `react-native init` — the library will not load on iOS. Run `npm run android` to try the demo.
+
 # Getting Started
 
 > **Note**: Make sure you have completed the [Set Up Your Environment](https://reactnative.dev/docs/set-up-your-environment) guide before proceeding.


### PR DESCRIPTION
## Summary

Adds a one-line callout at the top of \`example/README.md\` explaining that NetSignal is Android-only and the iOS scaffolding in \`example/ios/\` (plus \`npm run ios\`) is dead weight from \`react-native init\`.

## Audit context

Quick audit confirmed the published package is clean — Android-only declared in:
- root \`README.md\` Platform badge + Requirements section
- \`package.json\` \`files\` excludes any iOS folder
- \`codegenConfig\` has only \`android.javaPackageName\`
- no \`.podspec\` or root-level \`ios/\`

The only misleading surface was \`example/README.md\`, which still walked through CocoaPods setup. This PR pins a note up front; deleting the iOS scaffolding entirely is out of scope.

## Test plan

- [ ] Visual check: note renders at the top of the example README on the PR diff page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)